### PR TITLE
Removes cssify

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-define-lodash",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "Can",
     "JS",
@@ -63,7 +53,6 @@
   },
   "devDependencies": {
     "can-compute": "^3.0.0-pre.15",
-    "cssify": "^0.6.0",
     "documentjs": "^0.4.2",
     "done-serve": "^0.3.0-pre.0",
     "donejs-cli": "^0.10.0-pre.0",


### PR DESCRIPTION
This removes cssify from the project, as it is not used and including it
breaks Browserify usage.